### PR TITLE
Create sequences before tables

### DIFF
--- a/src/Schema/Visitor/CreateSchemaSqlCollector.php
+++ b/src/Schema/Visitor/CreateSchemaSqlCollector.php
@@ -91,8 +91,8 @@ class CreateSchemaSqlCollector extends AbstractVisitor
     {
         return array_merge(
             $this->createNamespaceQueries,
-            $this->createTableQueries,
             $this->createSequenceQueries,
+            $this->createTableQueries,
             $this->createFkConstraintQueries
         );
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

When generating the schema, sequences must be created before tables if the sequence is referenced in a column definition.

```php
/**
 *@ORM\Column(name="id", options={"default":"nextval('my_table_id_seq'::regclass)"})
 */
```

Without this you will get the following error:
```
 SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "my_table_id_seq" does not exist
```

